### PR TITLE
Pretty-printing for records containing functions

### DIFF
--- a/Text/Show/Pretty/Functions.hs
+++ b/Text/Show/Pretty/Functions.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-module Text.Show.PrettyFunctions where
+module Text.Show.Pretty.Functions where
 
 instance Show (a -> b) where
   showsPrec _ _ = showString "_fn"

--- a/Text/Show/PrettyFunctions.hs
+++ b/Text/Show/PrettyFunctions.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Text.Show.PrettyFunctions where
 
 instance Show (a -> b) where

--- a/Text/Show/PrettyFunctions.hs
+++ b/Text/Show/PrettyFunctions.hs
@@ -1,0 +1,4 @@
+module Text.Show.PrettyFunctions where
+
+instance Show (a -> b) where
+  showsPrec _ _ = showString "_fn"

--- a/pretty-show.cabal
+++ b/pretty-show.cabal
@@ -34,6 +34,7 @@ extra-source-files:
 library
   exposed-modules:
     Text.Show.Pretty
+    Text.Show.PrettyFunctions
   other-modules:
     Text.Show.Html
     Text.Show.Parser

--- a/pretty-show.cabal
+++ b/pretty-show.cabal
@@ -34,7 +34,7 @@ extra-source-files:
 library
   exposed-modules:
     Text.Show.Pretty
-    Text.Show.PrettyFunctions
+    Text.Show.Pretty.Functions
   other-modules:
     Text.Show.Html
     Text.Show.Parser

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,6 +1,8 @@
+{-# LANGUAGE FlexibleInstances #-}
 module Main where
 
 import Text.Show.Pretty (ppShow,reify,parseValue)
+import Text.Show.PrettyFunctions ()
 import Test.QuickCheck
 import Data.Maybe
 import Control.Monad
@@ -32,6 +34,7 @@ data D2
     | Int Int
     | L [D2]
     | T (D2,D2)
+    | F (Int -> Int)
   deriving (Eq,Show,Read)
 
 newtype Floaty = Floaty Float
@@ -50,6 +53,14 @@ instance Arbitrary Floaty where
     ,(1,return $ Floaty ((-1)/0))
     ]
 
+
+instance Eq (a -> a) where
+  (==) _ _ = True
+
+instance Read (a -> a) where
+  readsPrec _ str = [ (id, rest) | ("_fn", rest) <- lex str ]
+
+
 arbD :: Int -> Gen D
 arbD s = frequency $
     [ (1,return X) ]
@@ -67,6 +78,7 @@ arbD2 s = frequency $
     , (1,String <$> arbitrary)
     , (1,Ratio <$> arbitrary)
     , (1,Float <$> arbitrary)
+    , (1,pure $ F id)
     , (s,K <$> arbD2 s')
     , (s,do
         l <- choose (0,3)

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,7 +1,7 @@
 module Main where
 
 import Text.Show.Pretty (ppShow,reify)
-import Text.Show.PrettyFunctions ()
+import Text.Show.Pretty.Functions ()
 import Test.QuickCheck
 import Data.Maybe
 import Control.Monad

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,13 +1,10 @@
-{-# LANGUAGE FlexibleInstances #-}
 module Main where
 
-import Text.Show.Pretty (ppShow,reify,parseValue)
+import Text.Show.Pretty (ppShow,reify)
 import Text.Show.PrettyFunctions ()
 import Test.QuickCheck
 import Data.Maybe
 import Control.Monad
-
-import Control.Applicative
 
 infixr 4 :+:
 infixl 3 :$:
@@ -34,8 +31,16 @@ data D2
     | Int Int
     | L [D2]
     | T (D2,D2)
-    | F (Int -> Int)
+    | F Fun
   deriving (Eq,Show,Read)
+
+newtype Fun = Fun (Int -> Int) deriving Show
+
+instance Eq Fun where
+  _ == _ = True
+
+instance Read Fun where
+  readsPrec p = readParen (p > 10) $ \str -> [(Fun id, str2) | ("Fun", str1) <- lex str, ("_fn", str2) <- lex str1]
 
 newtype Floaty = Floaty Float
   deriving (Show,Read)
@@ -52,13 +57,6 @@ instance Arbitrary Floaty where
     ,(1,return $ Floaty (1/0))
     ,(1,return $ Floaty ((-1)/0))
     ]
-
-
-instance Eq (a -> a) where
-  (==) _ _ = True
-
-instance Read (a -> a) where
-  readsPrec _ str = [ (id, rest) | ("_fn", rest) <- lex str ]
 
 
 arbD :: Int -> Gen D
@@ -78,7 +76,7 @@ arbD2 s = frequency $
     , (1,String <$> arbitrary)
     , (1,Ratio <$> arbitrary)
     , (1,Float <$> arbitrary)
-    , (1,pure $ F id)
+    , (1,pure $ F $ Fun id)
     , (s,K <$> arbD2 s')
     , (s,do
         l <- choose (0,3)


### PR DESCRIPTION
Records containing functions just fall back to `show`, this should improve the situation.
