### PR TITLE
Hidden `Prelude.<>`

### DIFF
--- a/Text/Show/Pretty.hs
+++ b/Text/Show/Pretty.hs
@@ -11,6 +11,7 @@
 -- Functions for human-readable derived 'Show' instances.
 --------------------------------------------------------------------------------
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE Safe #-}
 module Text.Show.Pretty
   ( -- * Generic representation of values
@@ -46,6 +47,12 @@ import Text.Show.Html
 import Data.Foldable(Foldable,toList)
 import Language.Haskell.Lexer(rmSpace,lexerPass0)
 import Paths_pretty_show (getDataDir)
+
+#if MIN_VERSION_base(4,11,0)
+import Prelude hiding ( (<>) )
+#else
+import Prelude
+#endif
 
 {-# DEPRECATED ppValue "Please use `valToDoc` instead." #-}
 ppValue :: Value -> Doc

--- a/pretty-show.cabal
+++ b/pretty-show.cabal
@@ -22,6 +22,10 @@ homepage:       http://wiki.github.com/yav/pretty-show
 cabal-version:  >= 1.8
 build-type:     Simple
 
+tested-with:    GHC == 7.10.3
+                GHC == 8.0.2
+                GHC == 8.2.2
+
 data-files:
   style/jquery.js
   style/jquery-src.js


### PR DESCRIPTION
GHC 8.4.1-alpha1 was [announced](https://mail.haskell.org/pipermail/ghc-devs/2017-December/015235.html). While testing [Agda](https://github.com/agda/agda) with this version of GHC, I got the following errors:

```
$ cabal install
...
[6 of 6] Compiling Text.Show.Pretty ( Text/Show/Pretty.hs, dist/build/Text/Show/Pretty.o )

Text/Show/Pretty.hs:133:32: error:
    Ambiguous occurrence ‘<>’
    It could refer to either ‘Prelude.<>’,
                             imported from ‘Prelude’ at Text/Show/Pretty.hs:15:8-23
                             (and originally defined in ‘GHC.Base’)
                          or ‘Text.PrettyPrint.<>’,
                             imported from ‘Text.PrettyPrint’ at Text/Show/Pretty.hs:41:1-23
                             (and originally defined in ‘Text.PrettyPrint.HughesPJ’)
    |
133 |   Neg v            -> char '-' <> ppAtom v
    |                                ^^

Text/Show/Pretty.hs:175:34: error:
    Ambiguous occurrence ‘<>’
    It could refer to either ‘Prelude.<>’,
                             imported from ‘Prelude’ at Text/Show/Pretty.hs:15:8-23
                             (and originally defined in ‘GHC.Base’)
                          or ‘Text.PrettyPrint.<>’,
                             imported from ‘Text.PrettyPrint’ at Text/Show/Pretty.hs:41:1-23
                             (and originally defined in ‘Text.PrettyPrint.HughesPJ’)
    |
175 | blockWith _ a b []      = char a <> char b
    |                                  ^^
Failed to install pretty-show-1.6.15
```

This PR fix these issues.

Blocking https://github.com/agda/agda/issues/2878. 