### PR TITLE
Support for quasi-quotes

### DIFF
--- a/Text/Show/Html.hs
+++ b/Text/Show/Html.hs
@@ -71,6 +71,7 @@ valToHtml opts = loop
           Char {}    -> wideList (wideListWidth opts) $ map loop vs
           Date {}    -> wideList (wideListWidth opts) $ map loop vs
           Time {}    -> wideList (wideListWidth opts) $ map loop vs
+          Quote {}   -> wideList (wideListWidth opts) $ map loop vs
           String {}  -> tallList                      $ map loop vs
           InfixCons {} -> tallList                    $ map loop vs
 
@@ -87,6 +88,7 @@ valToHtml opts = loop
       String txt  -> span "string"  (text txt)
       Date txt    -> span "date"    (text txt)
       Time txt    -> span "time"    (text txt)
+      Quote txt   -> span "quote"   (text txt)
 
   conLab _          = " "
 

--- a/Text/Show/Parser.y
+++ b/Text/Show/Parser.y
@@ -38,6 +38,7 @@ import Data.List(intercalate)
         QCONID          { (Qconid,   (_,$$)) }
         CONSYM          { (Consym,   (_,$$)) }
         QCONSYM         { (Qconsym,  (_,$$)) }
+        QQUOTE          { (QQuote,   (_,$$)) }
         RESOP           { (Reservedop, (_,$$)) }
         RESID           { (Reservedid, (_,$$)) }
 
@@ -76,6 +77,7 @@ avalue                       :: { Value }
   | INT '-' INT '-' INT         { mkDate $1 $3 $5 }
   | INT ':' INT ':' INT         { mkTime $1 $3 $5 }
   | INT ':' INT ':' FLOAT       { mkTime $1 $3 $5 }
+  | QQUOTE                      { Quote $1 }
 
 
 con                          :: { String }

--- a/Text/Show/Pretty.hs
+++ b/Text/Show/Pretty.hs
@@ -167,6 +167,7 @@ valToDoc val = case val of
   String x         -> text x
   Date x           -> text x
   Time x           -> text x
+  Quote x          -> text x
 
 
 -- | This type is used to allow pre-processing of values before showing them.

--- a/Text/Show/Value.hs
+++ b/Text/Show/Value.hs
@@ -42,6 +42,7 @@ data Value    = Con Name [Value]               -- ^ Data constructor
               | String String                  -- ^ String
               | Date String                    -- ^ 01-02-2003
               | Time String                    -- ^ 08:30:21
+              | Quote String                   -- ^ [time|2003-02-01T08:30:21Z|]
                 deriving (Eq,Show)
 
 {- | Hide constrcutros matching the given predicate.
@@ -97,5 +98,6 @@ hideCon collapse hidden = toVal . delMaybe
       String {}   -> Just val
       Date {}     -> Just val
       Time {}     -> Just val
+      Quote {}    -> Just val
 
 


### PR DESCRIPTION
This depends on https://github.com/yav/haskell-lexer/pull/7

I assume it won't build prior to that making it to Hackage.

I called the constructor `Quote` as I assume it would be also be used for the other kinds of quotes if those were added.

There is something a bit unsatisfying about it being `Quote String` instead of `Quote Name String`, I think we'd need to come up with a more clever lexer to fix that.