### PR TITLE
Escape bracket [ for Quote constructor comment

### DIFF
--- a/Text/Show/Value.hs
+++ b/Text/Show/Value.hs
@@ -42,7 +42,7 @@ data Value    = Con Name [Value]               -- ^ Data constructor
               | String String                  -- ^ String
               | Date String                    -- ^ 01-02-2003
               | Time String                    -- ^ 08:30:21
-              | Quote String                   -- ^ [time|2003-02-01T08:30:21Z|]
+              | Quote String                   -- ^ \[time|2003-02-01T08:30:21Z|]
                 deriving (Eq,Show)
 
 {- | Hide constrcutros matching the given predicate.


### PR DESCRIPTION
I noticed on Hackage that Haddock was interpreting `[` as the start of bold styling which looks wrong.

![image](https://user-images.githubusercontent.com/134805/73500359-621bd700-43fd-11ea-8ef7-e47da931f987.png)

So this PR escapes it:

![image](https://user-images.githubusercontent.com/134805/73500547-f6863980-43fd-11ea-830b-c9e9a2783f40.png)

I did try `@code@` at first but looked a bit out of place among the other comments.