### PR TITLE
Remove unused dependencies

### DIFF
--- a/pretty-show.cabal
+++ b/pretty-show.cabal
@@ -46,10 +46,10 @@ library
     Text.Show.PrettyVal
     Paths_pretty_show
   build-depends:
-    array          >= 0.2  &&  < 2,
-    base           >= 4.5  &&  < 5,
-    haskell-lexer  >= 1.1    &&  < 2,
-    pretty         >= 1    &&  < 2,
+    array          >= 0.2 && < 2,
+    base           >= 4.6 && < 5,
+    haskell-lexer  >= 1.1 && < 2,
+    pretty         >= 1   && < 2,
     text
   ghc-options: -Wall -O2
   if impl(ghc < 7.4)
@@ -63,7 +63,7 @@ executable ppsh
 
   hs-source-dirs: bin
   build-depends:
-    base          >= 4.5  &&  < 5,
+    base          >= 4.6 && < 5,
     pretty-show
   ghc-options: -Wall
 

--- a/pretty-show.cabal
+++ b/pretty-show.cabal
@@ -50,11 +50,7 @@ library
     base           >= 4.5  &&  < 5,
     haskell-lexer  >= 1.1    &&  < 2,
     pretty         >= 1    &&  < 2,
-    text,
-    filepath,
-    unordered-containers,
-    hashable,
-    ghc-prim
+    text
   ghc-options: -Wall -O2
   if impl(ghc < 7.4)
     cpp-options: -DNO_GENERICS


### PR DESCRIPTION
These dependencies aren't used anywhere as far as I can tell.

I think `ghc-prim` might have been needed for `GHC.Generics` in `base-4.5`, but it's hard to confirm, since there are no old enough versions of `ghc-prim` on Hackage. I bumped `base` to `>= 4.6` to be sure.